### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ def _linkcode_resolve(domain, info):
         return None
     if not info['module']:
         return None
-    return "https://bitbucket.org/emacsway/sqlbuilder/src/default/%s" % get_module_path(info['module'])
+    return "https://bitbucket.org/emacsway/sqlbuilder/src/default/{0!s}".format(get_module_path(info['module']))
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/sqlbuilder/smartsql/contrib/evaluate.py
+++ b/sqlbuilder/smartsql/contrib/evaluate.py
@@ -39,12 +39,12 @@ class SymbolBase(object):
 
     def nud(self, parser):
         raise SyntaxError(
-            "Syntax error (%r)." % self.name
+            "Syntax error ({0!r}).".format(self.name)
         )
 
     def led(self, left, parser):
         raise SyntaxError(
-            "Unknown operator (%r)." % self.name
+            "Unknown operator ({0!r}).".format(self.name)
         )
 
     def evaluate(self, context):
@@ -52,7 +52,7 @@ class SymbolBase(object):
 
     def __repr__(self):
         if self.name == '(NAME)' or self.name == '(LITERAL)':
-            return "(%s %s)" % (self.name[1:-1], self.value)
+            return "({0!s} {1!s})".format(self.name[1:-1], self.value)
         out = [repr(self.name), self.first, self.second, self.third]
         out = map(str, filter(None, out))
         return '(' + ' '.join(out) + ')'


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlbuilder?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlbuilder?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
